### PR TITLE
Default locale selection to en_US if header is not set

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -4,7 +4,7 @@ app = (supported) ->
     do supported.index
 
   (req, res, next) ->
-    locales = new Locales req.headers["accept-language"]
+    locales = new Locales req.headers["accept-language"] or "en_US"
 
     req.locale = String locales.best supported
     do next


### PR DESCRIPTION
An error is caused if the client doesn't send a header.
