### PR TITLE
Best method does not return "real" best match

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -65,7 +65,10 @@ class app.Locales
     index = do locales.index
 
     for item in @
-      return item if index[item]
+      if index[item]
+        return item 
+      else 
+        if index[item.language] then locale = item
 
     locale
 


### PR DESCRIPTION
Example code:

``` javascript
var langSupported = new locale.Locales(['de', 'en', 'fr']);
var langHeader = new locale.Locales('de_DE'); // de_DE is returned for example from german IE 10
var lang = langHeader.best(langSupported);
```

If I understand that correctly lang should be 'de', because it's the best match. But instead of that the default locale ('en') is returned. Maybe my understanding is wrong, but it seems logical to me to return 'de' in that case, because 'de' is a better match for 'de_DE' than 'en'.
I attached a pull request, but I'm rather new to coffeescript and not entirely sure it works as designed currently and my fix is a bad fix. Maybe you can clarify that :smile: 
