### PR TITLE
No good way to unset default

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -24,7 +24,10 @@ class app.Locale
     value = [@language]
     value.push @country if @country
 
-    value.join "_"
+    if @language
+        return value.join "_"
+    else
+        return null
 
   toString: serialize
   toJSON: serialize


### PR DESCRIPTION
I'd like to be able to run without a default language set because when using this as an express middleware I want to have a different default language in different contexts so I need to know if there wasn't a best match.

I've accomplished this by setting locale.Locale.default to be `null` but the serialization turns that back into a string, so I have to do a string compare instead of just a truth check.
