### PR TITLE
Travis builds failing for all node 0.6 modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.6
+  - 0.8

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepublish": "coffee -o lib/ -c src/"
   },
   "engines": {
-    "node": ">0.6.x <=1.0.0"
+    "node": ">0.8.x <=1.0.0"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Travis' npm fails with SSL errors for anything on node.js 0.6. We can either turn off strict SSL checking or switch to node.js >= 0.8. I have no idea how many people are still using 0.6
