### PR TITLE
Instance default

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The default locale for the environment, as parsed from `process.env.LANG`. This 
 
 ### locales = new locale.Locales(acceptLanguageHeader, default)
 
-The Locales constructor takes a string compliant with the [`Accept-Language` HTTP header][header], and returns a list of acceptible locales, optionally sorted in descending order by quality score. Second argument is optional default value used as the fallback when the best language is calculated.
+The Locales constructor takes a string compliant with the [`Accept-Language` HTTP header][header], and returns a list of acceptible locales, optionally sorted in descending order by quality score. Second argument is optional default value used as the fallback when the best language is calculated. Otherwise locale.Locale["default"] is used as fallback.
 
 ### locales.best([supportedLocales])
 

--- a/README.md
+++ b/README.md
@@ -71,21 +71,21 @@ The Locale constructor takes a [language tag][langtag] string consisting of an I
 
 ### locale.Locale["default"]
 
-The default locale for the environment, as parsed from `process.env.LANG`. This is used as the fallback when the best language is calculated from the intersection of requested and supported locales.
+The default locale for the environment, as parsed from `process.env.LANG`. This is used as the fallback when the best language is calculated from the intersection of requested and supported locales and supported languages has not default.
 
-### locales = new locale.Locales(acceptLanguageHeader)
+### locales = new locale.Locales(acceptLanguageHeader, default)
 
-The Locales constructor takes a string compliant with the [`Accept-Language` HTTP header][header], and returns a list of acceptible locales, optionally sorted in descending order by quality score.
+The Locales constructor takes a string compliant with the [`Accept-Language` HTTP header][header], and returns a list of acceptible locales, optionally sorted in descending order by quality score. Second argument is optional default value used as the fallback when the best language is calculated.
 
 ### locales.best([supportedLocales])
 
 This method takes the target locale and compares it against the optionally provided list of supported locales, and returns the most appropriate locale based on the quality scores of the target locale.  If no exact match exists (i.e. language+country) then it will fallback to `language` if supported, or if the language isn't supported it will return the default locale.
 
-    supported = new locale.Locales(['en', 'en_US']);
+    supported = new locale.Locales(['en', 'en_US'], 'en');
     (new locale.Locales('en')).best(supported).toString();     // 'en'
     (new locale.Locales('en_GB')).best(supported).toString();  // 'en'
     (new locale.Locales('en_US')).best(supported).toString();  // 'en_US'
-    (new locale.Locales('jp')).best(supported);                // locale.Locale["default"]
+    (new locale.Locales('jp')).best(supported);                // supported.default || locale.Locale["default"]
 
 
 Copyright

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,6 @@
-app = (supported) ->
+app = (supported, def) ->
   unless supported instanceof Locales
-    supported = new Locales supported
+    supported = new Locales supported, def
     do supported.index
 
   (req, res, next) ->
@@ -60,7 +60,10 @@ class app.Locales
     @_index
 
   best: (locales) ->
-    locale = @def or Locale.default
+
+    locale = Locale.default
+    if locales and locales.default
+      locale = locales.default
 
     unless locales
       return @[0] or locale

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -39,7 +39,10 @@ class app.Locales
   sort: Array::sort
   push: Array::push
 
-  constructor: (str, @default) ->
+  constructor: (str, def) ->
+    if def
+      @default = new Locale def
+
     return unless str
 
     for item in (String str).split ","

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -25,9 +25,9 @@ class app.Locale
     value.push @country if @country
 
     if @language
-        return value.join "_"
+      return value.join "_"
     else
-        return null
+      return null
 
   toString: serialize
   toJSON: serialize
@@ -39,7 +39,7 @@ class app.Locales
   sort: Array::sort
   push: Array::push
 
-  constructor: (str) ->
+  constructor: (str, @default) ->
     return unless str
 
     for item in (String str).split ","
@@ -60,7 +60,7 @@ class app.Locales
     @_index
 
   best: (locales) ->
-    locale = Locale.default
+    locale = @def or Locale.default
 
     unless locales
       return @[0] or locale

--- a/src/test.coffee
+++ b/src/test.coffee
@@ -33,6 +33,15 @@ describe "Defaults", ->
       )
       callback()
 
+  it "should fallback to the instance default for unsupported languages.", (callback) ->
+    instanceDefault = 'en-GB'
+    supportedLocales = new locale.Locales ["da-DK"], instanceDefault
+    assert.equal(
+      (new locale.Locales("cs,en-US;q=0.8,en;q=0.6")).best(supportedLocales)
+      instanceDefault
+    )
+    callback()
+
 describe "Priority", ->
   it "should fallback to a more general language if a country specific language isn't available.", (callback) ->
     http.get port: 8000, headers: "Accept-Language": "en-GB", (res) ->

--- a/src/test.coffee
+++ b/src/test.coffee
@@ -33,11 +33,11 @@ describe "Defaults", ->
       )
       callback()
 
-  it "should fallback to the instance default for unsupported languages.", (callback) ->
-    instanceDefault = 'en-GB'
+  it "should fallback to the instance default for unsupported languages if instance default is defined.", (callback) ->
+    instanceDefault = 'en_GB'
     supportedLocales = new locale.Locales ["da-DK"], instanceDefault
     assert.equal(
-      (new locale.Locales "cs,en-US;q=0.8,en;q=0.6").best supportedLocales
+      ((new locale.Locales "cs,en-US;q=0.8,en;q=0.6").best supportedLocales).toString()
       instanceDefault
     )
     callback()

--- a/src/test.coffee
+++ b/src/test.coffee
@@ -37,7 +37,7 @@ describe "Defaults", ->
     instanceDefault = 'en-GB'
     supportedLocales = new locale.Locales ["da-DK"], instanceDefault
     assert.equal(
-      (new locale.Locales("cs,en-US;q=0.8,en;q=0.6")).best(supportedLocales)
+      (new locale.Locales "cs,en-US;q=0.8,en;q=0.6").best supportedLocales
       instanceDefault
     )
     callback()


### PR DESCRIPTION
When more then one instance of supported languages is needed, each instance should be able to have different default value.