### PR TITLE
Wrong language chosen from long list

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -50,7 +50,7 @@ class app.Locales
 
       @push locale
 
-    @sort (a, b) -> a.score < b.score
+    @sort (a, b) -> b.score - a.score
 
   index: ->
     unless @_index


### PR DESCRIPTION
I haven't narrowed down the specifics of why this is happening yet:

```
var supported = new locale.Locales([ 'af_ZA', 'ca_ES', 'de_DE', 'en_GB', 'en_US', 'es_ES', 'fr_FR', 'hi_IN', 'it_IT', 'nl_NL', 'pl_PL', 'pt_PT', 'pt_BR', 'ru_RU', 'sv_SE', 'tr_TR', 'val_ES', 'zh_CN' ]);
new locale.Locales('en-US,en;q=0.93,es-ES;q=0.87,es;q=0.80,it-IT;q=0.73,it;q=0.67,de-DE;q=0.60,de;q=0.53,fr-FR;q=0.47,fr;q=0.40,ja;q=0.33,zh-Hans-CN;q=0.27,zh-Hans;q=0.20,ar-SA;q=0.13,ar;q=0.067').best(supported).toString();
```

Gives `de_DE` which is before `en_US` in the supported list, but has a lower priority.
