### PR TITLE
Match country-specific language codes when separator is different

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -21,6 +21,10 @@ class app.Locale
     @language = do language.toLowerCase
     @country  = do country.toUpperCase if country
 
+    normalized = [@language]
+    normalized.push @country if @country
+    @normalized = normalized.join "_"
+
   serialize = ->
     if @language
         return @code
@@ -53,7 +57,7 @@ class app.Locales
   index: ->
     unless @_index
       @_index = {}
-      @_index[locale] = yes for locale in @
+      @_index[locale.normalized] = idx for locale, idx in @
 
     @_index
 
@@ -66,9 +70,11 @@ class app.Locales
     index = do locales.index
 
     for item in @
-      if index[item]
-        return item
-      else if index[item.language] then return new Locale item.language
+      normalizedIndex = index[item.normalized]
+      languageIndex = index[item.language]
+
+      if normalizedIndex? then return locales[normalizedIndex]
+      else if languageIndex? then return locales[languageIndex]
       else
         for l in locales
           if l.language == item.language then return l

--- a/src/test.coffee
+++ b/src/test.coffee
@@ -9,7 +9,7 @@ defaultLocale = locale.Locale.default
 before (callback) ->
   app = do express
 
-  app.use locale ["en-US", "fr", "en", "ja", "de", "da-DK"]
+  app.use locale ["en-US", "fr", "fr-CA", "en", "ja", "de", "da-DK"]
   app.get "/", (req, res) ->
     res.set "content-language", req.locale
     res.set "Connection", "close"
@@ -79,6 +79,14 @@ describe "Priority", ->
       assert.equal(
         res.headers["content-language"]
         "da-DK"
+      )
+      callback()
+
+  it "should match country-specific language codes even when the separator is different", (callback) ->
+    http.get port: 8000, headers: "Accept-Language": "fr_CA", (res) ->
+      assert.equal(
+        res.headers["content-language"]
+        "fr-CA"
       )
       callback()
 


### PR DESCRIPTION
My last PR (#23) introduced a regression whereby two locales with the same language and country codes but a different separator ("-" vs. "_") would not correctly match. An example of how this can happen:

``` js
var userLocales = new locale.Locales(['en_US']);
var supportedLocales = new locale.Locales(['en', 'en-US']);
var bestLocale = userLocales.best(supportedLocales).toString(); // returns `en` instead of `en-US`
```

This happened because the `best()` method was matching locales based on their `toString()` values, which now returns the original code (instead of one always separated with an "_").

This PR fixes that bug by introducing a normalized attribute on the `Locale` specifically for use when matching locales using `best()`. In addition, I altered the `index()` method on `Locales` to map the locale code to the array index at which that `Locale` object is located in the supported locales array passed in to `best()` so that we could return the original `Locale` object passed in.

Let me know if you have any questions and sorry for the regression.
