### PR TITLE
Added instance default - rebased and updated tests by @rhagigi

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,21 @@ The Locale constructor takes a [language tag][langtag] string consisting of an I
 
 ### locale.Locale["default"]
 
-The default locale for the environment, as parsed from `process.env.LANG`. This is used as the fallback when the best language is calculated from the intersection of requested and supported locales.
+The default locale for the environment, as parsed from `process.env.LANG`. This is used as the fallback when the best language is calculated from the intersection of requested and supported locales and supported languages has not default.
 
-### locales = new locale.Locales(acceptLanguageHeader)
+### locales = new locale.Locales(acceptLanguageHeader, default)
 
-The Locales constructor takes a string compliant with the [`Accept-Language` HTTP header][header], and returns a list of acceptible locales, optionally sorted in descending order by quality score.
+The Locales constructor takes a string compliant with the [`Accept-Language` HTTP header][header], and returns a list of acceptible locales, optionally sorted in descending order by quality score. Second argument is optional default value used as the fallback when the best language is calculated. Otherwise locale.Locale["default"] is used as fallback.
 
 ### locales.best([supportedLocales])
 
 This method takes the target locale and compares it against the optionally provided list of supported locales, and returns the most appropriate locale based on the quality scores of the target locale.  If no exact match exists (i.e. language+country) then it will fallback to `language` if supported, or if the language isn't supported it will return the default locale.
 
-    supported = new locale.Locales(['en', 'en_US']);
+    supported = new locale.Locales(['en', 'en_US'], 'en');
     (new locale.Locales('en')).best(supported).toString();     // 'en'
     (new locale.Locales('en_GB')).best(supported).toString();  // 'en'
     (new locale.Locales('en_US')).best(supported).toString();  // 'en_US'
-    (new locale.Locales('jp')).best(supported);                // locale.Locale["default"]
+    (new locale.Locales('jp')).best(supported);                // supported.default || locale.Locale["default"]
 
 
 Copyright

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,9 +3,9 @@
   var Locale, Locales, app, _ref,
     __slice = [].slice;
 
-  app = function(supported) {
+  app = function(supported, def) {
     if (!(supported instanceof Locales)) {
-      supported = new Locales(supported);
+      supported = new Locales(supported, def);
       supported.index();
     }
     return function(req, res, next) {
@@ -68,8 +68,11 @@
 
     Locales.prototype.push = Array.prototype.push;
 
-    function Locales(str) {
+    function Locales(str, def) {
       var item, locale, q, _i, _len, _ref, _ref1;
+      if (def) {
+        this["default"] = new Locale(def);
+      }
       if (!str) {
         return;
       }
@@ -107,6 +110,9 @@
         return r;
       };
       locale = Locale["default"];
+      if (locales && locales["default"]) {
+        locale = locales["default"];
+      }
       locale.defaulted = true;
       if (!locales) {
         if (this[0]) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -37,7 +37,7 @@
         return callback();
       });
     });
-    return it("should fallback to the default for unsupported languages.", function(callback) {
+    it("should fallback to the default for unsupported languages.", function(callback) {
       return http.get({
         port: 8001,
         headers: {
@@ -48,6 +48,13 @@
         assert.equal(true, !!res.headers["defaulted"]);
         return callback();
       });
+    });
+    return it("should fallback to the instance default for unsupported languages if instance default is defined.", function(callback) {
+      var instanceDefault, supportedLocales;
+      instanceDefault = 'en_GB';
+      supportedLocales = new locale.Locales(["da-DK"], instanceDefault);
+      assert.equal(((new locale.Locales("cs,en-US;q=0.8,en;q=0.6")).best(supportedLocales)).toString(), instanceDefault);
+      return callback();
     });
   });
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,6 @@
-app = (supported) ->
+app = (supported, def) ->
   unless supported instanceof Locales
-    supported = new Locales supported
+    supported = new Locales supported, def
     do supported.index
 
   (req, res, next) ->
@@ -29,9 +29,9 @@ class app.Locale
 
   serialize = ->
     if @language
-        return @code
+      return @code
     else
-        return null
+      return null
 
   toString: serialize
   toJSON: serialize
@@ -43,7 +43,10 @@ class app.Locales
   sort: Array::sort
   push: Array::push
 
-  constructor: (str) ->
+  constructor: (str, def) ->
+    if def
+      @default = new Locale def
+
     return unless str
 
     for item in (String str).split ","
@@ -70,6 +73,8 @@ class app.Locales
       return r
 
     locale = Locale.default
+    if locales and locales.default
+      locale = locales.default
     locale.defaulted = true
 
     unless locales

--- a/src/test.coffee
+++ b/src/test.coffee
@@ -36,6 +36,15 @@ describe "Defaults", ->
       assert.equal(true, !!res.headers["defaulted"])
       callback()
 
+  it "should fallback to the instance default for unsupported languages if instance default is defined.", (callback) ->
+    instanceDefault = 'SomeFakeLanguage-NotReal'
+    supportedLocales = new locale.Locales ["en-US", "fr", "fr-CA", "en", "ja", "de", "da-DK"], instanceDefault
+    assert.equal(
+      ((new locale.Locales "es-ES").best supportedLocales).toString()
+      instanceDefault
+    )
+    callback()
+
 describe "Priority", ->
   it "should fallback to a more general language if a country specific language isn't available.", (callback) ->
     http.get port: 8001, headers: "Accept-Language": "en-GB", (res) ->


### PR DESCRIPTION
Closing #35 and opening this nicely squashed rebased version. Adds ability to add a default per instance programmatically instead of using process.ENV or changing the global default for all Locale instances. 

Originally opened as #20.

Fixes #27 
Fixes #26

@jed @florrain